### PR TITLE
Add a README and a LICENSE file to the project

### DIFF
--- a/LICENSE.md
+++ b/LICENSE.md
@@ -1,0 +1,21 @@
+# MIT License
+
+Copyright (c) [2025] [Yannick Lohse, Sebastian Wagner]
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.

--- a/README.md
+++ b/README.md
@@ -1,0 +1,39 @@
+# Not-Paint
+
+This is a simple web-app that provides basic drawing capabilities.
+
+## Planned features
+
+- Pencil and Eraser [ ]
+- Undo and Redo [ ]
+- Amicable performance [ ]
+- Selecting of singular drawing parts or whole drawings [ ]
+- Exporting selections [ ]
+- Exporting selections to image formats like PNG and SVG [ ]
+- Inserting of images [ ]
+- Inserting images from clipboard [ ]
+- Cross session persistence (keeping the drawing state and undo/redo stack in between sessions), [ ]
+- Serialization of images (Saving drawings to files in a human readable format like json) [ ]
+- PWA support [ ]
+
+## Dev setup
+
+### Clone the repository
+
+```sh
+git clone git@github.com:eczovian/not-paint.git 
+```
+
+### Install the required dependencies
+
+```sh
+npm i
+```
+
+### Run the development server
+
+```sh
+npx vite serve
+```
+
+## **THIS APPLICATION IS NOT PRODUCTION READY USE AT YOUR OWN RISK**


### PR DESCRIPTION
Added a README and a LICENSE.

The README details the planned milestones for the project as well as instructions on how to run the project.
License of choise is the MIT License since it grants other developers the freedom to modify and redistribute the project more or less as they please (the terms of the license apply here).

closes #1 